### PR TITLE
Add wheels for Python 3.12

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -132,7 +132,9 @@ jobs:
             platform_id: macosx_arm64
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
 
     - name: Set up QEMU
       if: ${{ matrix.platform_id == 'manylinux_aarch64' }}

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -211,23 +211,23 @@ jobs:
         deactivate
 
   # See: https://github.com/pypa/gh-action-pypi-publish/discussions/15
-  deploy:
-    name: Upload wheels to PyPI
-    needs: [ build-wheels ]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment:
-      name: pypi
-      url: https://pypi.org/p/pyjpegls
-    permissions:
-      id-token: write
-
-    steps:
-    - name: Download the wheels
-      uses: actions/download-artifact@v4
-      with:
-        path: dist/
-        merge-multiple: true
-
-    - name: Publish package to PyPi
-      uses: pypa/gh-action-pypi-publish@release/v1
+  # deploy:
+  #   name: Upload wheels to PyPI
+  #   needs: [ build-wheels ]
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 10
+  #   environment:
+  #     name: pypi
+  #     url: https://pypi.org/p/pyjpegls
+  #   permissions:
+  #     id-token: write
+  #
+  #   steps:
+  #   - name: Download the wheels
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       path: dist/
+  #       merge-multiple: true
+  #
+  #   - name: Publish package to PyPi
+  #     uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -3,9 +3,9 @@ name: release-deploy
 on:
   release:
     types: [ published ]
-  push:
-    branches: [ main ]
-  pull_request:
+  # push:
+  #   branches: [ main ]
+  # pull_request:
 
 jobs:
   build-sdist:
@@ -213,23 +213,23 @@ jobs:
         deactivate
 
   # See: https://github.com/pypa/gh-action-pypi-publish/discussions/15
-  # deploy:
-  #   name: Upload wheels to PyPI
-  #   needs: [ build-wheels ]
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 10
-  #   environment:
-  #     name: pypi
-  #     url: https://pypi.org/p/pyjpegls
-  #   permissions:
-  #     id-token: write
-  #
-  #   steps:
-  #   - name: Download the wheels
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       path: dist/
-  #       merge-multiple: true
-  #
-  #   - name: Publish package to PyPi
-  #     uses: pypa/gh-action-pypi-publish@release/v1
+  deploy:
+    name: Upload wheels to PyPI
+    needs: [ build-wheels ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyjpegls
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download the wheels
+      uses: actions/download-artifact@v4
+      with:
+        path: dist/
+        merge-multiple: true
+
+    - name: Publish package to PyPi
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -3,9 +3,9 @@ name: release-deploy
 on:
   release:
     types: [ published ]
-  # push:
-  #   branches: [ main ]
-  # pull_request:
+  push:
+    branches: [ main ]
+  pull_request:
 
 jobs:
   build-sdist:

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -3,6 +3,9 @@ name: release-deploy
 on:
   release:
     types: [ published ]
+  # push:
+  #   branches: [ main ]
+  # pull_request:
 
 jobs:
   build-sdist:
@@ -10,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       name: Install Python
       with:
         python-version: '3.10'
@@ -22,13 +25,13 @@ jobs:
     - name: Build sdist
       run: |
         python -m pip install -U pip
-        python -m pip install numpy cython
-        python setup.py sdist
+        python -m pip install build
+        python -m build --sdist
 
     - name: Store artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: sdist
         path: ./dist
 
   build-wheels:
@@ -40,9 +43,6 @@ jobs:
         include:
           # Windows 64 bit
           - os: windows-latest
-            python: 37
-            platform_id: win_amd64
-          - os: windows-latest
             python: 38
             platform_id: win_amd64
           - os: windows-latest
@@ -53,14 +53,13 @@ jobs:
             platform_id: win_amd64
           - os: windows-latest
             python: 311
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 312
             platform_id: win_amd64
 
           # Linux 64 bit manylinux2014
           - os: ubuntu-latest
-            python: 37
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
             python: 38
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
@@ -74,14 +73,15 @@ jobs:
             manylinux_image: manylinux2014
           - os: ubuntu-latest
             python: 311
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 312
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
           # Linux aarch64
           - os: ubuntu-latest
-            python: 37
-            platform_id: manylinux_aarch64
-          - os: ubuntu-latest
             python: 38
             platform_id: manylinux_aarch64
           - os: ubuntu-latest
@@ -92,13 +92,13 @@ jobs:
             platform_id: manylinux_aarch64
           - os: ubuntu-latest
             python: 311
+            platform_id: manylinux_aarch64
+          - os: ubuntu-latest
+            python: 312
             platform_id: manylinux_aarch64
 
           # MacOS x86_64
           - os: macos-latest
-            python: 37
-            platform_id: macosx_x86_64
-          - os: macos-latest
             python: 38
             platform_id: macosx_x86_64
           - os: macos-latest
@@ -109,6 +109,9 @@ jobs:
             platform_id: macosx_x86_64
           - os: macos-latest
             python: 311
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 312
             platform_id: macosx_x86_64
 
           # MacOS arm64
@@ -123,6 +126,9 @@ jobs:
             platform_id: macosx_arm64
           - os: macos-latest
             python: 311
+            platform_id: macosx_arm64
+          - os: macos-latest
+            python: 312
             platform_id: macosx_arm64
 
     steps:
@@ -142,7 +148,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install -U pip
-        python -m pip install cibuildwheel==2.12.0
+        python -m pip install cibuildwheel>=2.16
 
     - name: Build wheels
       env:
@@ -157,12 +163,52 @@ jobs:
         python -m cibuildwheel --output-dir dist
 
     - name: Store artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheel-${{ matrix.python }}-${{ matrix.platform_id }}
         path: ./dist
 
-  # Todo: download and test the packages after we have working tests
+  test-package:
+    name: Test built package
+    needs: [ build-wheels, build-sdist ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+
+    steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Download the wheels
+      uses: actions/download-artifact@v4
+      with:
+        path: dist/
+        merge-multiple: true
+
+    - name: Install from package wheels and test
+      run: |
+        python -m venv testwhl
+        source testwhl/bin/activate
+        python -m pip install -U pip
+        python -m pip install pytest numpy
+        python -m pip install -U --pre --find-links dist/ pyjpegls
+        python -m pytest --pyargs jpeg_ls.tests
+        deactivate
+
+    - name: Install from package tarball and test
+      run: |
+        python -m venv testsrc
+        source testsrc/bin/activate
+        python -m pip install -U pip
+        python -m pip install pytest numpy
+        python -m pip install -U dist/pyjpegls*.tar.gz
+        python -m pytest --pyargs jpeg_ls.tests
+        deactivate
 
   # See: https://github.com/pypa/gh-action-pypi-publish/discussions/15
   deploy:
@@ -178,10 +224,10 @@ jobs:
 
     steps:
     - name: Download the wheels
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: wheels
         path: dist/
+        merge-multiple: true
 
     - name: Publish package to PyPi
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,6 @@ include lib/charls/src/*
 include lib/charls/include/charls/*
 include lib/charls/README.md
 include jpeg_ls/tests/jlsimV100/*
+include jpeg_ls/*.cpp
+include jpeg_ls/*.h
+include jpeg_ls/*.pyx

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include lib/charls/src/*
+include lib/charls/include/charls/*
+include lib/charls/README.md
+include jpeg_ls/tests/jlsimV100/*

--- a/jpeg_ls/__init__.py
+++ b/jpeg_ls/__init__.py
@@ -4,7 +4,7 @@ from .CharLS import encode, decode, write, read  # noqa: F401
 from _CharLS import encode_to_buffer, decode_from_buffer  # noqa: F401
 
 
-__version__ = "1.1.0.dev0"
+__version__ = "1.1.0"
 
 
 # Setup default logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ license = {text = "MIT"}
 name = "pyjpegls"
 readme = "readme.md"
 requires-python = ">=3.8"
-version = "1.1.0.dev0"
+version = "1.1.0"
 
 [project.urls]
 documentation = "https://pydicom.github.io/pydicom"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,3 @@ repository = "https://github.com/pydicom/pyjpegls"
 
 [tool.setuptools.packages.find]
 include = ["jpeg_ls*"]
-exclude = ["jpeg_ls/tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = [
 
 classifiers = [
     "License :: OSI Approved :: MIT License",
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
+    "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -40,5 +41,6 @@ download = "https://github.com/pydicom/pyjpegls/archive/master.zip"
 homepage = "https://github.com/pydicom/pyjpegls"
 repository = "https://github.com/pydicom/pyjpegls"
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools.packages.find]
+include = ["jpeg_ls*"]
+exclude = ["jpeg_ls/tests"]


### PR DESCRIPTION
Updates the release workflow:
* Remove Python 3.7 and add 3.12, closes #9 
* Use newer versions of various actions
* Test wheels and sdist before deploy
* Successful run: https://github.com/pydicom/pyjpegls/actions/runs/7568964953

